### PR TITLE
Replace ⚉ with 💀︎ (skull), so it renders more like Netronics.

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
       function drawChar(char, color, x, y) {
         if (x >= 0 && x < terminal.width && y >= 0 && y < terminal.height) {
           const el = terminal.grid[y][x]
-          el.innerText = char
+          el.innerText = char.replace('⚉', '💀\ufe0e')
           el.style.color = 'var(--color-' + color + ')'
         }
       }


### PR DESCRIPTION
This is used by Flappy Birb whenever the birb hits a wall:

<img width="182" alt="Screen Shot 2022-07-24 at 10 06 01" src="https://user-images.githubusercontent.com/246847/180626753-7502902b-8dde-4a8d-a6ce-889deb9f030e.png">

With this PR:

<img width="748" alt="Screen Shot 2022-07-24 at 10 03 59" src="https://user-images.githubusercontent.com/246847/180626711-a71b5295-0374-434c-8a92-74826bdfc670.png">

I couldn't find a simple solution for the alignment/clipping issue. Short of some CSS trickery, this may need to use bitmap font rendering.

I've got [Noto Emoji (monochrome)](https://fonts.google.com/noto/specimen/Noto+Emoji) installed on my machine, so the variation selector `\ufe0e` picks that rather than a colour font. I haven't included Noto Emoji as a web font because it seems like a significant overhead on the page for just 1 character.
